### PR TITLE
docs: deprecate wifi-api in favor of standalone repo

### DIFF
--- a/airodor_wifi_api/README.md
+++ b/airodor_wifi_api/README.md
@@ -2,6 +2,10 @@
 # airodor-wifi
 provide a  api for the airodor wifi module from limot
 
+> **⚠️ This project has moved!**
+> The WiFi API is now developed and maintained in a separate repository:
+> **[BenniWi/airodor-wifi-api](https://github.com/BenniWi/airodor-wifi-api)**
+
 ## install poetry
 
 ```bash


### PR DESCRIPTION
The WiFi API has been extracted into a dedicated standalone repository: https://github.com/BenniWi/airodor-wifi-api

This PR adds a deprecation notice to the README pointing users to the new repo.